### PR TITLE
Dragging stuff by symbol instead of word

### DIFF
--- a/drag-stuff.el
+++ b/drag-stuff.el
@@ -83,6 +83,10 @@
 (defvar drag-stuff-after-drag-hook nil
   "Called after dragging occurs.")
 
+(make-variable-buffer-local
+ (defvar drag-stuff-by-symbol-p nil
+   "If non-nil, drag by symbols instead of words with left/right."))
+
 (defun drag-stuff--kbd (key)
   "Key binding helper."
   (let ((mod (if (listp drag-stuff-modifier)
@@ -259,6 +263,14 @@
   "Drags word right ARG times."
   (drag-stuff-word-horizontally arg))
 
+(defun drag-stuff-symbol-left (arg)
+  "Drags symbol left ARG times"
+  (drag-stuff-symbol-horizontally (- arg)))
+
+(defun drag-stuff-symbol-right (arg)
+  "Drags word right ARG times."
+  (drag-stuff-symbol-horizontally arg))
+
 (defun drag-stuff-word-horizontally (arg)
   "Drags word horizontally ARG times."
   (let ((old-point (point))
@@ -266,6 +278,24 @@
     (condition-case err
         (progn
           (transpose-words arg)
+          (backward-char offset))
+      (error
+       (message
+        (if (> arg 0)
+            "Can not move word further to the right"
+          "Can not move word further to the left"))
+       (goto-char old-point)))))
+
+(defun drag-stuff-symbol-horizontally (arg)
+  "Drags word horizontally ARG times."
+  (let ((old-point (point))
+        (offset (- (save-excursion
+                     (forward-symbol 1)
+                     (point))
+                   (point))))
+    (condition-case err
+        (progn
+          (transpose-subr 'forward-symbol arg)
           (backward-char offset))
       (error
        (message


### PR DESCRIPTION
- Functions for dragging symbols left/right
- Buffer-local variable for controlling the behavior of
  `drag-stuff-right` and `drag-stuff-left`.
