### PR TITLE
Add emacs 25+ compatibility

### DIFF
--- a/drag-stuff.el
+++ b/drag-stuff.el
@@ -83,6 +83,12 @@
 (defvar drag-stuff-after-drag-hook nil
   "Called after dragging occurs.")
 
+;; save-mark-and-excursion in Emacs 25 works like save-excursion did before
+(eval-when-compile
+  (when (not (fboundp #'save-mark-and-excursion))
+    (defmacro save-mark-and-excursion (&rest body)
+      `(save-excursion ,@body))))
+
 (defun drag-stuff--kbd (key)
   "Key binding helper."
   (let ((mod (if (listp drag-stuff-modifier)
@@ -180,7 +186,7 @@
   (let* ((deactivate-mark nil)
          (mark-line (line-number-at-pos (mark)))
          (point-line (line-number-at-pos (point)))
-         (mark-col (save-excursion (exchange-point-and-mark) (current-column)))
+         (mark-col (save-mark-and-excursion (exchange-point-and-mark) (current-column)))
          (point-col (current-column))
          (bounds (drag-stuff-whole-lines-region))
          (beg (car bounds))
@@ -262,7 +268,7 @@
 (defun drag-stuff-word-horizontally (arg)
   "Drags word horizontally ARG times."
   (let ((old-point (point))
-        (offset (- (save-excursion (forward-word) (point)) (point))))
+        (offset (- (save-mark-and-excursion (forward-word) (point)) (point))))
     (condition-case err
         (progn
           (transpose-words arg)


### PR DESCRIPTION
`save-mark-and-excursion` should be used instead of `save-excursion`. From emacs 25 onwards, `save-excursion` does not save the mark and so the region drags do not work any more. That is fixed in this commit. This commit should also not break in older emacsen.

Source for fixes:

- https://github.com/magnars/expand-region.el/commit/69819ac1417b8fad6561f8072d76d0fa2fcebfc0
- https://github.com/magnars/expand-region.el/commit/1c210d72db67ff9045e02a2d8bb45a6815f42b4d