### PR TITLE
Leave drag-stuff-define-keys up to the user

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,6 +25,13 @@ To enable drag-stuff globally, use:
 (drag-stuff-global-mode 1)
 ```
 
+### Suggested key-bindings
+To activate the suggested key-bindings, `<M-up>`, `<M-down>`, `<M-right>`, `<M-left>`, use:
+
+```lisp
+(drag-stuff-define-keys)
+```
+
 ### Drag line
 To drag a line up and down. Put the cursor on that line and press
 `<M-up>` and `<M-down>`.

--- a/drag-stuff.el
+++ b/drag-stuff.el
@@ -338,9 +338,7 @@
   "Drag stuff around."
   :init-value nil
   :lighter " drag"
-  :keymap drag-stuff-mode-map
-  (when drag-stuff-mode
-    (drag-stuff-define-keys)))
+  :keymap drag-stuff-mode-map)
 
 ;;;###autoload
 (defun turn-on-drag-stuff-mode ()

--- a/features/conflicting-modes.feature
+++ b/features/conflicting-modes.feature
@@ -12,6 +12,7 @@ Feature: Drag Stuff
           ))
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I turn on auto-fill-mode
     And I drag line "3" up
     Then I should see:
@@ -34,6 +35,7 @@ Feature: Drag Stuff
       """
     And I turn on ruby-mode
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I turn on electric-indent-mode
     And I drag line "<line>" <direction>
     Then I should see:
@@ -57,6 +59,7 @@ Feature: Drag Stuff
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tristique sollicitudin massa, ut porta diam pellentesque et. Sed porttitor tempor egestas. Morbi accumsan quam sed elit auctor nec interdum mi tincidunt.
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I turn on longlines-mode
     And I drag line "1" down
     Then I should see:
@@ -76,6 +79,7 @@ Feature: Drag Stuff
       Move me down please
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I turn on longlines-mode
     And I drag line "5" up
     Then I should see:
@@ -94,5 +98,6 @@ Feature: Drag Stuff
       Ipsum
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I drag line "1" down
     Then longlines-mode should not be active

--- a/features/drag-stuff.feature
+++ b/features/drag-stuff.feature
@@ -5,6 +5,7 @@ Feature: Drag Stuff
 
   Scenario: Global mode
     When I turn on drag-stuff globaly
+    And I activate the suggested drag-stuff key-bindings
     And I open temp file "global"
     And I insert:
       """
@@ -20,6 +21,7 @@ Feature: Drag Stuff
 
   Scenario: Global mode except
     When I turn on drag-stuff globaly
+    And I activate the suggested drag-stuff key-bindings
     And I add "text-mode" as an except mode
     And I turn on text-mode
     Then drag-stuff-mode should not be active

--- a/features/evil-mode.feature
+++ b/features/evil-mode.feature
@@ -8,6 +8,7 @@ Feature: Drag Stuff for Evil Mode
       """
     And I turn on evil-mode
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I evil select region <beg>:<end>
     And I drag region <direction>
     Then I should see:
@@ -35,6 +36,7 @@ Feature: Drag Stuff for Evil Mode
       """
     And I turn on evil-mode
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I evil select region <beg>:<end>
     And I drag region <direction>
     And I drag region <direction>
@@ -67,6 +69,7 @@ Feature: Drag Stuff for Evil Mode
       """
     And I turn on evil-mode
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I evil select lines <begline>:<endline> at column <begcol>:<endcol>
     And I drag lines <direction>
     And I drag lines <direction>
@@ -97,6 +100,7 @@ Feature: Drag Stuff for Evil Mode
       """
     And I turn on evil-mode
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I evil select region <beg>:<end>
     And I drag region <direction>
     Then I should see:
@@ -125,6 +129,7 @@ Feature: Drag Stuff for Evil Mode
       """
     And I turn on evil-mode
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     And I evil select lines <begline>:<endline> at column <begcol>:<endcol>
     And I drag lines <direction>
     Then I should see:

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -9,6 +9,7 @@ Feature: Hooks
       line 4
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
 
   Scenario: Before and after wrap hooks
     Given I load the following:

--- a/features/line.feature
+++ b/features/line.feature
@@ -10,6 +10,7 @@ Feature: Drag line
       line 2
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
 
   Scenario: Drag line up
     When I drag line "2" up

--- a/features/lines.feature
+++ b/features/lines.feature
@@ -11,6 +11,7 @@ Feature: Drag lines
       line 3
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
 
   Scenario: Drag lines up
     When I drag lines "2" to "3" up

--- a/features/modifier.feature
+++ b/features/modifier.feature
@@ -17,6 +17,7 @@ Feature: Modifier
       (setq drag-stuff-modifier 'control)
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     When I press "<C-down>"
     Then I should see:
       """
@@ -30,6 +31,7 @@ Feature: Modifier
       (setq drag-stuff-modifier '(meta shift))
       """
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
     When I press "<M-S-down>"
     Then I should see:
       """

--- a/features/region.feature
+++ b/features/region.feature
@@ -6,6 +6,7 @@ Feature: Drag region
   Background: 
     Given I insert "beforeREGIONafter"
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
 
   Scenario: Drag region left
     When I drag region "REGION" left

--- a/features/step-definitions/drag-stuff-steps.el
+++ b/features/step-definitions/drag-stuff-steps.el
@@ -6,6 +6,10 @@
        (lambda ()
          (drag-stuff-mode 1)))
 
+(Given "^I activate the suggested drag-stuff key-bindings$"
+       (lambda ()
+         (drag-stuff-define-keys)))
+
 (Given "^I turn off drag-stuff$"
        (lambda ()
          (drag-stuff-mode -1)))

--- a/features/word.feature
+++ b/features/word.feature
@@ -6,6 +6,7 @@ Feature: Drag word
   Background: 
     Given I insert "word1 word2 word3"
     And I turn on drag-stuff
+    And I activate the suggested drag-stuff key-bindings
 
   Scenario: Drag word left
     When I drag word "word3" left


### PR DESCRIPTION
Putting a call to `drag-stuff-define-keys` in the body of code that runs whenever drag-stuff-mode is enabled/disabled makes it overly complicated to customize drag-stuff-mode-map when using drag-stuff-global-mode. The user's keybindings refuse to take hold unless they're wrapped in a function that's added to drag-stuff-mode-hook.

For example:
```emacs-lisp
(defun my/bind-drag-stuff-keys ()
  ;; unset the defaults
  (define-key drag-stuff-mode-map (drag-stuff--kbd 'up) nil)
  ...
  ;; apply my bindings
  (define-key drag-stuff-mode-map (kbd "C-M-k") 'drag-stuff-up)
  ...)

(add-hook 'drag-stuff-mode-hook
          'my/bind-drag-stuff-keys)

(drag-stuff-global-mode t)
```
Without resorting to the above use of hooks, any custom bindings get clobbered by drag-stuff-define-keys.

Resolve this issue by removing the call to drag-stuff-define-keys from the body of the minor mode definition and adding instructions to the README as to how users can activate the suggested keybindings.

See issue #21 